### PR TITLE
Change update option to update_as_unapproved

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -5,25 +5,37 @@ files:
     dest: /episodes/%file_name%.md
     type: md
     translation: /locale/%two_letters_code%/episodes/%original_file_name%
+    update_option: update_as_unapproved
   - source: /episodes/*.md
     translation: /locale/%two_letters_code%/episodes/%original_file_name%
+    update_option: update_as_unapproved
   - source: /instructors/*.md
     translation: /locale/%two_letters_code%/instructors/%original_file_name%
+    update_option: update_as_unapproved
   - source: /learners/*.md
     translation: /locale/%two_letters_code%/learners/%original_file_name%
+    update_option: update_as_unapproved
   - source: /profiles/*.md
     translation: /locale/%two_letters_code%/profiles/%original_file_name%
+    update_option: update_as_unapproved
   - source: /CODE_OF_CONDUCT.md
     translation: /locale/%two_letters_code%/%original_file_name%
+    update_option: update_as_unapproved
   - source: /config.yaml
     translation: /locale/%two_letters_code%/%original_file_name%
+    update_option: update_as_unapproved
   - source: /CONTRIBUTING.md
     translation: /locale/%two_letters_code%/%original_file_name%
+    update_option: update_as_unapproved
   - source: /LICENSE.md
     translation: /locale/%two_letters_code%/%original_file_name%
+    update_option: update_as_unapproved
   - source: /README.md
     translation: /locale/%two_letters_code%/%original_file_name%
+    update_option: update_as_unapproved
   - source: /index.md
     translation: /locale/%two_letters_code%/%original_file_name%
+    update_option: update_as_unapproved
   - source: /links.md
     translation: /locale/%two_letters_code%/%original_file_name%
+    update_option: update_as_unapproved


### PR DESCRIPTION
This preserves translations of changed strings and remove validations of those translations if they exist, instead of deleting the translation of the changed string

https://support.crowdin.com/developer/configuration-file/?_gl=1*t00g5h*_up*MQ..*_ga*MTQ2NTE3NTUwNS4xNzIwNTI0NjYw*_ga_SRNRQ29Q3E*MTcyMDUyNDY1OS4xLjAuMTcyMDUyNDY1OS4wLjAuMTczMDM5NjMxOQ#changed-strings-update

Should fix https://github.com/swcarpentry-ja/git-novice/issues/1